### PR TITLE
Add new formula for the Instant Client Basic.

### DIFF
--- a/Formula/instantclient-basic.rb
+++ b/Formula/instantclient-basic.rb
@@ -1,0 +1,20 @@
+require File.expand_path("../../Strategies/cache_wo_download", __FILE__)
+
+# A formula that installs the Instant Client Basic package.
+class InstantclientBasic < Formula
+  desc "Oracle Instant Client Basic x64."
+  homepage "http://www.oracle.com/technetwork/topics/intel-macsoft-096467.html"
+
+  url "http://download.oracle.com/otn/mac/instantclient/11204/instantclient-basic-macos.x64-11.2.0.4.0.zip",
+      :using => CacheWoDownloadStrategy
+  sha256 "6c079713ab0a65193f7bfcbad6c90e7806fa6634a3828052f8428e1533bb89d3"
+
+  # Use files provided by basiclite except NLS data.
+  depends_on "instantclient-basiclite"
+
+  def install
+    # NLS data only.
+    # All other files are same with basiclite.
+    lib.install ["libociei.dylib"]
+  end
+end


### PR DESCRIPTION
I added formula for the Instant Client Basic.
It depends on `instantclient-basiclite` formula.

The difference of basic and basic lite is only NLS data.
This formula installs NLS data only. All other files are provided by `instantclient-basiclite`.

Firstly, Oracle instant client tries to load `libociei.dylib` (NLS data provided by the basic package).
If it fails, it tries to load `libociicus.dylib` (NLS data provided by the basiclite pacakge).
So just adding `libociei.dylib` changes the basiclite package to the basic package.
