### PR TITLE
Fix dependent Oracle library paths embedded in sqlplus and Oracle libraries.

### DIFF
--- a/Formula/instantclient-basiclite.rb
+++ b/Formula/instantclient-basiclite.rb
@@ -1,4 +1,5 @@
 require File.expand_path("../../Strategies/cache_wo_download", __FILE__)
+require File.expand_path("../../instantclient-util", __FILE__)
 
 # A formula that installs the Instant Client Basic Lite package.
 class InstantclientBasiclite < Formula
@@ -9,7 +10,12 @@ class InstantclientBasiclite < Formula
       :using => CacheWoDownloadStrategy
   sha256 "d51c5fb67d1213c9b3c6301c6f73fe1bef45f78197e1bae7804df4c0abb468a7"
 
+  include InstantclientUtil
+
   def install
+    Dir["*.dylib*"].each do |file|
+      fix_oracle_lib_path(file)
+    end
     %w[libclntsh.dylib libocci.dylib].each do |dylib|
       ln_s "#{dylib}.11.1", dylib
     end

--- a/Formula/instantclient-sqlplus.rb
+++ b/Formula/instantclient-sqlplus.rb
@@ -1,4 +1,5 @@
 require File.expand_path("../../Strategies/cache_wo_download", __FILE__)
+require File.expand_path("../../instantclient-util", __FILE__)
 
 # A formula that installs the Instant Client SQLPlus package.
 class InstantclientSqlplus < Formula
@@ -11,7 +12,13 @@ class InstantclientSqlplus < Formula
 
   depends_on "instantclient-basiclite"
 
+  include InstantclientUtil
+
   def install
+    Dir["*.dylib"].each do |file|
+      fix_oracle_lib_path(file)
+    end
+    fix_oracle_lib_path("sqlplus")
     lib.install Dir["*.dylib"]
     bin.install ["sqlplus"]
   end

--- a/instantclient-util.rb
+++ b/instantclient-util.rb
@@ -1,0 +1,26 @@
+module InstantclientUtil
+  ORACLE_LIBRARIES = [
+    "libclntsh.dylib.11.1",
+    "libnnz11.dylib",
+    "libocci.dylib.11.1",
+    "libociei.dylib",
+    "libociicus.dylib",
+    "libocijdbc11.dylib",
+    "libsqlplus.dylib",
+    "libsqlplusic.dylib",
+  ]
+
+  # Fix dependent Oracle library paths
+  def fix_oracle_lib_path(file)
+    file = Pathname.new(file)
+    file.ensure_writable do
+      file.dynamically_linked_libraries.each do |fname|
+        next if fname[0] == '@'
+        if ORACLE_LIBRARIES.include? File.basename(fname)
+          system MacOS.locate("install_name_tool"), "-change", fname,
+                 HOMEBREW_PREFIX/"lib"/File.basename(fname), file
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
OS X executables and libraries include dependent dynamic shared library paths.

For example:

```
$ otool -L sqlplus 
sqlplus:
    /ade/dosulliv_sqlplus_mac/oracle/sqlplus/lib/libsqlplus.dylib (compatibility version 0.0.0, current version 0.0.0)
    /ade/b/2475221476/oracle/rdbms/lib/libclntsh.dylib.11.1 (compatibility version 0.0.0, current version 0.0.0)
    /ade/b/2475221476/oracle/ldap/lib/libnnz11.dylib (compatibility version 0.0.0, current version 0.0.0)
    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 159.1.0)
```

sqlplus tries to use libsqlplus.dylib in DYLD_LIBRARY_PATH. If it fails, it tries to use the embedded full path(/ade/dosulliv_sqlplus_mac/oracle/sqlplus/lib/libsqlplus.dylib) and then tries to use libsqlplus.dylib in DYLD_FALLBACK_LIBRARY_PATH.

The default value of DYLD_FALLBACK_PATH includes /usr/local. Thus if `brew --prefix` is /usr/local, sqlplus works without DYLD_LIBRARY_PATH. But if `brew --prefix` isn't /usr/local, sqlplus doesn't work without DYLD_LIBRARY_PATH.

This pull request fixes the embedded paths as follows:

```
$ otool -L sqlplus 
sqlplus:
    /brew_prefix_path/lib/libsqlplus.dylib (compatibility version 0.0.0, current version 0.0.0)
    /brew_prefix_path/lib/libclntsh.dylib.11.1 (compatibility version 0.0.0, current version 0.0.0)
    /brew_prefix_path/lib/libnnz11.dylib (compatibility version 0.0.0, current version 0.0.0)
    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 159.1.0)
```

sqlplus works without DYLD_LIBRARY_PATH even though `brew --prefix` isn't /usr/local.

This also fixes embedded paths in other libraries such as libclntsh.dylib.11.1.
