### PR TITLE
Fix dependent Oracle library paths embedded in Oracle libraries again.

### DIFF
--- a/Formula/instantclient-basic.rb
+++ b/Formula/instantclient-basic.rb
@@ -1,4 +1,5 @@
 require File.expand_path("../../Strategies/cache_wo_download", __FILE__)
+require File.expand_path("../../instantclient-util", __FILE__)
 
 # A formula that installs the Instant Client Basic package.
 class InstantclientBasic < Formula
@@ -12,9 +13,12 @@ class InstantclientBasic < Formula
   # Use files provided by basiclite except NLS data.
   depends_on "instantclient-basiclite"
 
+  include InstantclientUtil
+
   def install
     # NLS data only.
     # All other files are same with basiclite.
+    fix_oracle_lib_path("libociei.dylib")
     lib.install ["libociei.dylib"]
   end
 end

--- a/instantclient-util.rb
+++ b/instantclient-util.rb
@@ -14,6 +14,10 @@ module InstantclientUtil
   def fix_oracle_lib_path(file)
     file = Pathname.new(file)
     file.ensure_writable do
+      if file.basename.to_s == ORACLE_LIBRARIES[0] # libclntsh.dylib
+        system MacOS.locate("install_name_tool"), "-add_rpath",
+                 HOMEBREW_PREFIX/"lib", file
+      end
       file.dynamically_linked_libraries.each do |fname|
         next if fname[0] == "@"
         if ORACLE_LIBRARIES.include? File.basename(fname)


### PR DESCRIPTION
Sorry, GH-2 isn't correct.
GH-2 tries to make sqlplus work when homebrew is installed outside /usr/local.
But it works only when the current directory is the directory containing libclntsh.dylib.
It is my mistake. I should have checked whether sqlplus works in other directories.

This commit really fixed it.
