### PR TITLE
Don't use opt_prefix as the library ID of libclntsh.dylib.

### DIFF
--- a/Formula/instantclient-basiclite.rb
+++ b/Formula/instantclient-basiclite.rb
@@ -13,12 +13,15 @@ class InstantclientBasiclite < Formula
   include InstantclientUtil
 
   def install
-    Dir["*.dylib*"].each do |file|
-      fix_oracle_lib_path(file)
-    end
     %w[libclntsh.dylib libocci.dylib].each do |dylib|
       ln_s "#{dylib}.11.1", dylib
     end
     lib.install Dir["*.dylib*"]
+  end
+
+  def post_install
+    Dir[lib/"*.dylib*"].each do |file|
+      fix_oracle_lib_path(file)
+    end
   end
 end

--- a/instantclient-util.rb
+++ b/instantclient-util.rb
@@ -18,6 +18,10 @@ module InstantclientUtil
         system MacOS.locate("install_name_tool"), "-add_rpath",
                  HOMEBREW_PREFIX/"lib", file
       end
+      if file.dylib_id
+        system MacOS.locate("install_name_tool"), "-id",
+               HOMEBREW_PREFIX/"lib"/File.basename(file.dylib_id), file
+      end
       file.dynamically_linked_libraries.each do |fname|
         next if fname[0] == "@"
         if ORACLE_LIBRARIES.include? File.basename(fname)


### PR DESCRIPTION
Homebrew rewrites dynamic library IDs relative to opt_prefix since [September 2015](https://github.com/Homebrew/homebrew/commit/3b0cbe6a56d9133941482a9e2d033ad86cdb5e79). For example, `libclntsh.dylib`'s library ID had been `/usr/local/lib/libclntsh.dylib.11.1` but it was changed to `/usr/local/opt/instantclient-basiclite/lib/libclntsh.dylib.11.1`. Unfortunately the change prevents third party applications compiled with Oracle client from using the instant client basic package.

When an application is compiled with a dynamic library, it depends on the library ID of the dynamic library. For example, when `libclntsh.dylib`'s library ID is `/usr/local/opt/instantclient-basiclite/lib/libclntsh.dylib.11.1`, third party applications compiled with the libclntsh.dylib uses `/usr/local/opt/instantclient-basiclite/lib/libclntsh.dylib.11.1` as its dependent library.

`libclntsh.dylib` tries to find NLS data `libociei.dylib(basic)` and then `libociicus.dylib(basiclite)` in the directory containing itself. When an application uses `/usr/local/opt/instantclient-basiclite/lib/libclntsh.dylib.11.1`, `libclntsh.dylib` thinks that it is in `/usr/local/opt/instantclient-basiclite/lib` and uses NLS data `libociicus.dylib` in the basiclite package even when the basic package is installed because NLS data `libociei.dylib` is in `/usr/local/lib` and `/usr/local/opt/instantclient-basic/lib`.

This commit changes the library ID to `/usr/local/lib/libclntsh.dylib.11.1`. When an application uses `/usr/local/lib/libclntsh.dylib.11.1`, `libclntsh.dylib` thinks that it is in `/usr/local/lib` and finds NLS data `libociei.dylib` in the basic package.
