### PR TITLE
Updated SHA256 for instantclient-basic after changes from 6/14/16

### DIFF
--- a/Formula/instantclient-basic.rb
+++ b/Formula/instantclient-basic.rb
@@ -7,7 +7,7 @@ class InstantclientBasic < Formula
 
   url "http://download.oracle.com/otn/mac/instantclient/121020/instantclient-basic-macos.x64-12.1.0.2.0.zip",
       :using => CacheWoDownloadStrategy
-  sha256 "8c72abe1ee29c6f85c82851cfe5cdfc31bff09e162438aa755fc76f7a78bd1b6"
+  sha256 "ecbf84ff011fcd8981c2cd9355f958ee42b2e452ebaad2d42df7b226903679cf"
 
   conflicts_with "instantclient-basiclite"
 

--- a/Formula/instantclient-basiclite.rb
+++ b/Formula/instantclient-basiclite.rb
@@ -7,7 +7,7 @@ class InstantclientBasiclite < Formula
 
   url "http://download.oracle.com/otn/mac/instantclient/121020/instantclient-basiclite-macos.x64-12.1.0.2.0.zip",
       :using => CacheWoDownloadStrategy
-  sha256 "80f1d2a0300bd485cb733f4c458f9e02344df62ed3c89d54354f9853b33e874c"
+  sha256 "ac7e97661a2bfac69b3262150641914f456c7806ba2a7850669fb83abac120e8"
 
   conflicts_with "instantclient-basic"
 

--- a/Formula/instantclient-sdk.rb
+++ b/Formula/instantclient-sdk.rb
@@ -7,7 +7,7 @@ class InstantclientSdk < Formula
 
   url "http://download.oracle.com/otn/mac/instantclient/121020/instantclient-sdk-macos.x64-12.1.0.2.0.zip",
       :using => CacheWoDownloadStrategy
-  sha256 "0e6d7cd228d9dc40e98a012fc450b47ca39263815b8842c6ede0a033e39927fd"
+  sha256 "63582d9a2f4afabd7f5e678c39bf9184d51625c61e67372acdbc7b42ed8530ac"
 
   def install
     # Ideally should go into includes but ruby-oci8 seems very picky...

--- a/Formula/instantclient-sqlplus.rb
+++ b/Formula/instantclient-sqlplus.rb
@@ -7,7 +7,7 @@ class InstantclientSqlplus < Formula
 
   url "http://download.oracle.com/otn/mac/instantclient/121020/instantclient-sqlplus-macos.x64-12.1.0.2.0.zip",
       :using => CacheWoDownloadStrategy
-  sha256 "8eb5bc4da372c6d58de3b3af30a5736a392278272ea04d4400e0b3926a9bf6b8"
+  sha256 "d1a83949aa742a4f7e5dfb39f5d2b15b5687c87edf7d998fe6caef2ad4d9ef6d"
 
   option "with-basiclite", "Depend on instantclient-basiclite instead of instantclient-basic."
 


### PR DESCRIPTION
instantclient-basic-macos.x64-12.1.0.2.0.zip was changed on 6/14/16. Updated SHA256.

See: http://www.oracle.com/technetwork/topics/intel-macsoft-096467.html
