### PR TITLE
Use 'all files' script for MacOS versions catalina or later

### DIFF
--- a/Formula/instantclient-sqlplus.rb
+++ b/Formula/instantclient-sqlplus.rb
@@ -17,7 +17,7 @@ class InstantclientSqlplus < Formula
     end
     lib.install Dir["*.dylib"]
     bin.install ["sqlplus"]
-    if MacOS.version == :catalina
+    if MacOS.version >= :catalina
       bin.env_script_all_files(libexec, "DYLD_LIBRARY_PATH" => HOMEBREW_PREFIX/"lib")
     end
   end


### PR DESCRIPTION
On macOS Big Sur 11.1 when running `sqlplus` I get the following error:

```
$ sqlplus
Error 6 initializing SQL*Plus
SP2-0667: Message file sp1<lang>.msb not found
SP2-0750: You may need to set ORACLE_HOME to your Oracle software directory
```

The instantclient-sqlplus formula has a special case for MacOS Catalina. Setting
the special case for Catalina or later versions fixes the error and `sqlplus` can
run.